### PR TITLE
Run the two Nullness Checkers in different builds.

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -17,7 +17,7 @@ true
 # This also builds annotation-tools and jsr308-langtools
 (cd $ROOT/checker-framework/ && ./.travis-build-without-test.sh)
 export CHECKERFRAMEWORK=$ROOT/checker-framework
- 
+
 ## Obtain daikon
 (cd $ROOT && git clone --depth 1 https://github.com/codespecs/daikon.git)
 ## Is the dyncomp-jdk task needed?
@@ -42,8 +42,10 @@ elif [[ "$1" == "interning" ]]; then
   make -C $ROOT/daikon/java check-interning
 elif [[ "$1" == "lock" ]]; then
   make -C $ROOT/daikon/java check-lock
-elif [[ "$1" == "nullness" ]]; then
-  make -C $ROOT/daikon/java check-nullness
+elif [[ "$1" == "nullness-fbc" ]]; then
+  make -C $ROOT/daikon/java check-nullness-fbc
+elif [[ "$1" == "nullness-raw" ]]; then
+  make -C $ROOT/daikon/java check-nullness-raw
 elif [[ "$1" == "regex" ]]; then
   make -C $ROOT/daikon/java check-regex
 elif [[ "$1" == "signature" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
   - GROUP=formatter
   - GROUP=interning
   - GROUP=lock
-  - GROUP=nullness
+  - GROUP=nullness-fbc
+  - GROUP=nullness-raw
   - GROUP=regex
   - GROUP=signature
 ## This is just to determine the time to do the background build.


### PR DESCRIPTION
This way the build doesn't timeout.